### PR TITLE
fix: Change typing of postBuild in BuildTimeConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.2.0] - 2025-03-30
+### Fixed
+- Fix the typing of `postBuild` in `BuildTimeConfig` when `postBuild` is present in the `BuilderConfiguration`.
+
+### Added
+- Add the `builder.reset()` method to reset the state of `sequence`, `unique`, and custom generators using `AbortSignal`;
+- Add `FieldType` export.
+
+
 ## [1.1.1] - 2025-03-28
 ### Fixed
 - Fix the behavior of builders using [generator functions](https://github.com/Stivooo/mimicry-js/tree/main?tab=readme-ov-file#using-generatorfunction-to-create-fields): the generator should be initialized on each call of the `one` and `many` methods.

--- a/README.md
+++ b/README.md
@@ -596,8 +596,9 @@ console.log(periods);
 > In this case, you can also use [overrides](#overrides-per-build) and [traits](#traits).
 
 > [!IMPORTANT]
-> Keep that the provided generator function is reinitialized each time the `many` or `one` methods are called.
+> It is important to note that only infinite generators are supported.
 
+The provided generator function is called each time the `many` or `one` methods are called.
 This means that each build will be independent of the others. This is necessary to prevent unrelated tests from affecting each other:
 
 ```ts
@@ -628,7 +629,7 @@ console.log(secondPeriodsSet);
 #### Passing `initialParameters` to the generator function
 
 It can be very useful to pass some initial values to the generator function at the moment of object generation. \
-So, `buildTimeConfig` has an optional `initialParameters` field, which accepts a tuple of arguments taken by the generator function:
+So, `BuildTimeConfig` has an optional `initialParameters` field, which accepts a tuple of arguments taken by the generator function:
 
 ```ts
 import {build, generate} from 'mimicry-js';
@@ -1008,6 +1009,9 @@ const [first, second, third] = builder.many(3);
 // second.exponent === 4
 // third.exponent === 8
 ```
+
+> [!IMPORTANT]
+> Keep in mind that only infinite generators are supported.
 
 ## Best practices for using TypeScript types
 

--- a/src/builder/__tests__/extractOverrides.ts
+++ b/src/builder/__tests__/extractOverrides.ts
@@ -1,7 +1,7 @@
 import {BuildTimeConfig, Overrides} from '../types';
 
-export function extractOverrides<Preset, Result, Parameters extends any[]>(
-    config?: BuildTimeConfig<Preset, unknown, Result, Parameters>,
-): Overrides<Preset> {
+export function extractOverrides<Origin, Result = Origin, PostBuildResult = Result>(
+    config?: BuildTimeConfig<Origin, Result, PostBuildResult>,
+): Overrides<Origin> {
     return config?.overrides ?? {};
 }

--- a/src/builder/builder.ts
+++ b/src/builder/builder.ts
@@ -21,29 +21,33 @@ import {extractOverrides} from './__tests__/extractOverrides';
 import {extractFieldsConfiguration} from './utils/extractFieldsConfiguration';
 import {extractInitialParameters} from './utils/extractInitialParameters';
 
-function createBuilder<Origin, Fields = Origin, Trait extends string = string, InitialParameters extends any[] = never>(
-    config: BuilderConfiguration<Origin, Fields, Trait, InitialParameters>,
-): Builder<Origin, Fields, Trait, InitialParameters> {
+function createBuilder<Origin, Result = Origin, Trait extends string = string, InitialParameters extends any[] = never>(
+    config: BuilderConfiguration<Origin, Result, Trait, InitialParameters>,
+): Builder<Origin, Result, Trait, InitialParameters> {
     const fieldsConfiguration = extractFieldsConfiguration(config.fields);
 
     const traits: TraitsConfiguration<Origin, Trait> | undefined = config.traits;
-    const postBuild: ((x: Origin) => Fields) | undefined = config.postBuild;
+    const postBuild: ((x: Origin) => Result) | undefined = config.postBuild;
 
     let definedIterators: IteratorsConfiguration<Origin> | null = null;
     let previousBuildFields: Origin | undefined;
     let fieldsConfigurationGenerator: FieldsConfigurationGenerator<Origin> | null = null;
 
-    const mapFieldsWithOverrides = <Fields = Origin, MapperBuild = Fields>(
+    const mapFieldsWithOverrides = <Fields = Origin, PostBuildResult = Result>(
         fields: FieldsConfiguration<Fields>,
-        buildConfig?: BuildTimeConfig<Fields, Trait, MapperBuild, InitialParameters>,
+        buildConfig?: BuildTimeConfig<Fields, Result, PostBuildResult, Trait>,
     ) => {
+        if (!isPlainObject(fields)) {
+            return fields;
+        }
+
         const buildOverrides = extractOverrides(buildConfig);
         const buildTraitsOverrides = extractTraits(buildConfig).reduce<Overrides<Fields>>(
             (traitsOverrides, traitKey) => {
                 if (!traits?.[traitKey]) {
                     console.warn(`Trait "${String(traitKey)}" is not specified in buildConfig!`);
                 }
-                const traitsConfig = traits ? traits[traitKey] : ({} as TraitsConfiguration<Origin>);
+                const traitsConfig = traits ? traits[traitKey] : ({} as TraitsConfiguration<Fields>);
                 const currentTraitOverrides = traitsConfig.overrides ?? {};
                 return deepMerge(traitsOverrides, currentTraitOverrides);
             },
@@ -100,7 +104,7 @@ function createBuilder<Origin, Fields = Origin, Trait extends string = string, I
         }
 
         if (isIterator(field)) {
-            return field.next().value;
+            return field.next().value as Value;
         }
 
         if (isClassInstance<Value>(field)) {
@@ -118,8 +122,8 @@ function createBuilder<Origin, Fields = Origin, Trait extends string = string, I
         return field;
     };
 
-    const initFieldsGenerator = <MapperBuild = Fields>(
-        buildConfig?: BuildTimeConfig<Origin, Trait, MapperBuild, InitialParameters>,
+    const initFieldsGenerator = <PostBuildResult = Result>(
+        buildConfig?: BuildTimeConfig<Origin, Result, PostBuildResult, Trait, InitialParameters>,
     ) => {
         if (!fieldsConfiguration.originFieldsGenerator) {
             return;
@@ -129,10 +133,8 @@ function createBuilder<Origin, Fields = Origin, Trait extends string = string, I
         fieldsConfigurationGenerator = fieldsConfiguration.originFieldsGenerator(...initialParameters);
     };
 
-    const build = <MapperBuild = Fields>(
-        buildConfig?: BuildTimeConfig<Origin, Trait, MapperBuild, InitialParameters>,
-    ) => {
-        let fieldsForProcessing;
+    const build = <PostBuildResult = Result>(buildConfig?: BuildTimeConfig<Origin, Result, PostBuildResult, Trait>) => {
+        let fieldsForProcessing: FieldsConfiguration<Origin>;
 
         if (fieldsConfiguration.originFieldsFunction) {
             const iterationFields = fieldsConfiguration.originFieldsFunction(previousBuildFields);
@@ -142,7 +144,8 @@ function createBuilder<Origin, Fields = Origin, Trait extends string = string, I
                 throw Error("The fields GeneratorFunction isn't initialized!");
             }
 
-            const iterationFields = fieldsConfigurationGenerator.next(previousBuildFields).value;
+            const iterationFields = fieldsConfigurationGenerator.next(previousBuildFields)
+                .value as FieldsConfiguration<Origin>;
             fieldsForProcessing = deepMerge(iterationFields, extractIterators(iterationFields));
         } else {
             fieldsForProcessing = fieldsConfiguration.originFields;
@@ -153,23 +156,24 @@ function createBuilder<Origin, Fields = Origin, Trait extends string = string, I
         previousBuildFields = fields as Origin;
 
         const built = postBuild ? postBuild(fields as Origin) : fields;
-        return buildConfig?.postBuild ? buildConfig.postBuild(built as Origin) : (built as MapperBuild);
+        return buildConfig?.postBuild ? buildConfig.postBuild(built as Result) : (built as PostBuildResult);
     };
 
     return {
-        one: <Result = Fields>(buildConfig?: BuildTimeConfig<Origin, Trait, Result, InitialParameters>) => {
+        one: <PostBuildResult = Result>(buildConfig?: BuildTimeConfig<Origin, Result, PostBuildResult, Trait>) => {
             initFieldsGenerator(buildConfig);
             return build(buildConfig);
         },
-        many: <Result = Fields>(
+        many: <PostBuildResult = Result>(
             count: number,
-            buildConfig?: BuildTimeConfig<Origin, Trait, Result, InitialParameters>,
+            buildConfig?: BuildTimeConfig<Origin, Result, PostBuildResult, Trait>,
         ) => {
             initFieldsGenerator(buildConfig);
             return Array(count)
                 .fill(0)
                 .map(() => build(buildConfig));
         },
+        reset: () => {},
     };
 }
 

--- a/src/builder/types.ts
+++ b/src/builder/types.ts
@@ -3,68 +3,73 @@ import type {FieldsGenerator} from '../generators/generate';
 
 export type FunctionalGenerator<T> = () => T;
 
-export type FieldGenerator<T> = FunctionalGenerator<T> | Iterator<T, T>;
+export type FieldGenerator<T> = FunctionalGenerator<T> | Iterator<T, never | void>;
 
 export type FieldType<T> = T | FixedValue<T> | FieldGenerator<T> | FieldsConfiguration<T>;
 
-export type FieldsConfiguration<Result> = {
-    readonly [Key in keyof Result]: FieldType<Result[Key]>;
+export type FieldsConfiguration<Origin> = {
+    readonly [Key in keyof Origin]: FieldType<Origin[Key]>;
 };
 
-export type FieldsConfigurationFunction<FactoryResult> = (
-    prevBuild?: FactoryResult,
-) => FieldsConfiguration<FactoryResult>;
+export type FieldsConfigurationFunction<Origin> = (prevBuild?: Origin) => FieldsConfiguration<Origin>;
 
-export type FieldsConfigurationGenerator<FactoryResult> = Generator<
-    FieldsConfiguration<FactoryResult>,
-    FieldsConfiguration<FactoryResult>,
-    FactoryResult | undefined
+export type FieldsConfigurationGenerator<Origin> = Generator<
+    FieldsConfiguration<Origin>,
+    never | void,
+    Origin | undefined
 >;
 
-export type FieldsConfigurationGeneratorFunction<FactoryResult, InitialParameters extends any[] = never> = (
+export type FieldsConfigurationGeneratorFunction<Origin, InitialParameters extends any[] = never> = (
     ...initialParameters: InitialParameters
-) => FieldsConfigurationGenerator<FactoryResult>;
+) => FieldsConfigurationGenerator<Origin>;
 
-export type BuilderConfigurationFields<FactoryResult, InitialParameters extends any[] = never> =
-    | FieldsConfiguration<FactoryResult>
-    | FieldsConfigurationFunction<FactoryResult>
-    | FieldsGenerator<FactoryResult, InitialParameters>;
+export type BuilderConfigurationFields<Origin, InitialParameters extends any[] = never> =
+    | FieldsConfiguration<Origin>
+    | FieldsConfigurationFunction<Origin>
+    | FieldsGenerator<Origin, InitialParameters>;
 
 export type BuilderConfiguration<
-    FactoryResult,
-    PostBuildResult = FactoryResult,
+    Origin,
+    PostBuildResult = Origin,
     TraitName extends string = string,
     InitialParameters extends any[] = never,
 > = {
-    readonly fields: BuilderConfigurationFields<FactoryResult, InitialParameters>;
-    readonly traits?: TraitsConfiguration<FactoryResult, TraitName>;
-    readonly postBuild?: (x: FactoryResult) => PostBuildResult;
+    readonly fields: BuilderConfigurationFields<Origin, InitialParameters>;
+    readonly traits?: TraitsConfiguration<Origin, TraitName>;
+    readonly postBuild?: (x: Origin) => PostBuildResult;
 };
 
 export type Overrides<Result> = {
     [Key in keyof Result]?: FieldType<Result[Key]> | Overrides<Result[Key]>;
 };
 
-export type BuildTimeConfig<Result, Trait, MappedResult = Result, InitialParameters extends any[] = never> = {
-    overrides?: Overrides<Result>;
-    postBuild?: (builtThing: Result) => MappedResult;
-    traits?: Trait | Trait[];
+export type BuildTimeConfig<
+    Origin,
+    StaticPostBuildResult = Origin,
+    PostBuildResult = StaticPostBuildResult,
+    TraitName = string,
+    InitialParameters extends any[] = never,
+> = {
+    overrides?: Overrides<Origin>;
+    postBuild?: (builtThing: StaticPostBuildResult) => PostBuildResult;
+    traits?: TraitName | TraitName[];
     initialParameters?: InitialParameters;
 };
 
 export interface Builder<
-    FactoryResult,
-    PostBuildResult = FactoryResult,
+    Origin,
+    PostBuildResult = Origin,
     TraitName extends string = string,
     InitialParameters extends any[] = never,
 > {
     one<Result = PostBuildResult>(
-        buildTimeConfig?: BuildTimeConfig<FactoryResult, TraitName, Result, InitialParameters>,
+        buildTimeConfig?: BuildTimeConfig<Origin, PostBuildResult, Result, TraitName, InitialParameters>,
     ): Result;
     many<Result = PostBuildResult>(
         count: number,
-        buildTimeConfig?: BuildTimeConfig<FactoryResult, TraitName, Result, InitialParameters>,
+        buildTimeConfig?: BuildTimeConfig<Origin, PostBuildResult, Result, TraitName, InitialParameters>,
     ): Result[];
+    reset(): void;
 }
 
 export type IteratorsConfiguration<T> = {[Key in keyof T]: IteratorsConfiguration<T[Key]> | Iterator<T[Key]>};

--- a/src/builder/utils/extractTraits.ts
+++ b/src/builder/utils/extractTraits.ts
@@ -1,7 +1,7 @@
 import {BuildTimeConfig} from '../types';
 
-export function extractTraits<Result, Trait extends string, MappedResult, Parameters extends any[]>(
-    buildTimeConfig?: BuildTimeConfig<Result, Trait, MappedResult, Parameters>,
+export function extractTraits<Origin, Result = Origin, PostBuildResult = Result, Trait extends string = string>(
+    buildTimeConfig?: BuildTimeConfig<Origin, Result, PostBuildResult, Trait>,
 ) {
     const traits = buildTimeConfig?.traits;
     return Array.isArray(traits) ? traits : traits ? [traits] : [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,5 @@ export type {
     FieldsConfigurationGeneratorFunction,
     TraitsConfiguration,
     Overrides,
+    FieldType,
 } from './builder/types';


### PR DESCRIPTION
### Fixed
- Fix the typing of `postBuild` in `BuildTimeConfig` when `postBuild` is present in the `BuilderConfiguration`.

### Added
- Add the `builder.reset()` method to reset the state of `sequence`, `unique`, and custom generators using [`AbortSignal`];
- Add `FieldType` export.